### PR TITLE
Refactor effectSupernewvoltsDestroyMonster to use chain system

### DIFF
--- a/server/src/game/actions/handlers/effectSupernewvoltsDestroyMonster.spec.ts
+++ b/server/src/game/actions/handlers/effectSupernewvoltsDestroyMonster.spec.ts
@@ -1,0 +1,91 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { EffectType, Zone } from 'src/graphql/index';
+import { GameChainStatus } from 'src/models/game-chain.model';
+import { GameChainLinkStatus } from 'src/models/game-chain-link.model';
+import { handleEffectSupernewvoltsDestroyMonster } from './effectSupernewvoltsDestroyMonster';
+
+describe('handleEffectSupernewvoltsDestroyMonster', () => {
+  it('should create a game chain with a chain link for SUPERNEWVOLTS_DESTROY_MONSTER effect', () => {
+    const gameCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user1',
+      zone: Zone.BATTLE,
+    });
+
+    const targetGameCard = new GameCardModel({
+      id: 2,
+      currentUserId: 'user2',
+      zone: Zone.BATTLE,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameUsers: [],
+      gameCards: [gameCard, targetGameCard],
+      gameChains: [],
+    });
+
+    const result = handleEffectSupernewvoltsDestroyMonster(
+      'user1',
+      {
+        gameCard,
+        targetGameCard,
+      },
+      gameModel,
+    );
+
+    expect(result.gameChains).toHaveLength(1);
+
+    const gameChain = result.gameChains[0];
+    expect(gameChain?.status).toBe(GameChainStatus.RESOLVING);
+    expect(gameChain?.gameChainLinks).toHaveLength(1);
+
+    const chainLink = gameChain?.gameChainLinks[0];
+    expect(chainLink?.orderIndex).toBe(0);
+    expect(chainLink?.userId).toBe('user1');
+    expect(chainLink?.gameCardId).toBe(1);
+    expect(chainLink?.status).toBe(GameChainLinkStatus.WAITING);
+    expect(chainLink?.effect.type).toBe(EffectType.SUPERNEWVOLTS_DESTROY_MONSTER);
+
+    if (chainLink?.effect.type === EffectType.SUPERNEWVOLTS_DESTROY_MONSTER) {
+      expect(chainLink.effect.payload).toEqual({
+        gameCard,
+        targetGameCard,
+      });
+    }
+  });
+
+  it('should not consume any energy (effect has no cost)', () => {
+    const gameCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user1',
+      zone: Zone.BATTLE,
+    });
+
+    const targetGameCard = new GameCardModel({
+      id: 2,
+      currentUserId: 'user2',
+      zone: Zone.BATTLE,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameUsers: [],
+      gameCards: [gameCard, targetGameCard],
+      gameChains: [],
+    });
+
+    const result = handleEffectSupernewvoltsDestroyMonster(
+      'user1',
+      {
+        gameCard,
+        targetGameCard,
+      },
+      gameModel,
+    );
+
+    // Energy should remain unchanged (no cost processing)
+    expect(result.gameUsers).toEqual(gameModel.gameUsers);
+  });
+});

--- a/server/src/game/actions/handlers/effectSupernewvoltsDestroyMonster.ts
+++ b/server/src/game/actions/handlers/effectSupernewvoltsDestroyMonster.ts
@@ -1,8 +1,8 @@
 import { GameCardModel } from 'src/models/game-card.model';
 import { GameModel } from 'src/models/game.model';
-import { saveEffectUseCountGameState } from './effectSupernewvoltsDestroyMonster/saveEffectUseCountGameState';
-import { moveDeckTopCardToMorgue } from './effectSupernewvoltsDestroyMonster/moveDeckTopCardToMorgue';
-import { moveTargetMonsterToMorgue } from './effectSupernewvoltsDestroyMonster/moveTargetMonsterToMorgue';
+import { GameChainModel, GameChainStatus } from 'src/models/game-chain.model';
+import { GameChainLinkModel, GameChainLinkStatus } from 'src/models/game-chain-link.model';
+import { EffectType } from 'src/graphql/index';
 
 export type EffectSupernewvoltsDestroyMonsterActionPayload = {
   gameCard: GameCardModel;
@@ -14,8 +14,29 @@ export function handleEffectSupernewvoltsDestroyMonster(
   payload: EffectSupernewvoltsDestroyMonsterActionPayload,
   gameModel: GameModel,
 ): GameModel {
-  gameModel = moveDeckTopCardToMorgue(gameModel, userId);
-  gameModel = moveTargetMonsterToMorgue(gameModel, payload.targetGameCard);
-  saveEffectUseCountGameState(gameModel, payload.gameCard);
+  // No cost processing needed for this effect
+
+  const gameChain = new GameChainModel({
+    gameId: gameModel.id,
+    status: GameChainStatus.RESOLVING, // TODO: WAITINGにしたい。今はGameChainLinkConfirmationの概念がないためRESOLVINGにしている
+    gameChainLinks: [
+      new GameChainLinkModel({
+        orderIndex: 0,
+        userId,
+        gameCardId: payload.gameCard.id,
+        status: GameChainLinkStatus.WAITING,
+        effect: {
+          type: EffectType.SUPERNEWVOLTS_DESTROY_MONSTER,
+          payload: {
+            gameCard: payload.gameCard,
+            targetGameCard: payload.targetGameCard,
+          },
+        },
+      }),
+    ],
+  });
+
+  gameModel.gameChains = [...gameModel.gameChains, gameChain];
+
   return gameModel;
 }

--- a/server/src/game/chains/resolvers/index.ts
+++ b/server/src/game/chains/resolvers/index.ts
@@ -3,6 +3,7 @@ import { GameChainLinkModel, GameChainLinkStatus } from 'src/models/game-chain-l
 import { EffectType } from 'src/graphql/index';
 import { resolveRuteruteDraw } from './ruteruteDraw';
 import { resolveNatsukashinorudePowerDown } from './natsukashinorudePowerDown';
+import { resolveSupernewvoltsDestroyMonster } from './supernewvoltsDestroyMonster';
 import { getResolvingGameChain } from 'src/game/selectors/getResolvingGameChain';
 import { markGameChainAsResolved } from 'src/game/mutations/markGameChainAsResolved';
 import { markGameChainLinkAsResolving } from 'src/game/mutations/markGameChainLinkAsResolving';
@@ -50,6 +51,9 @@ export class ChainResolver {
       }
       case EffectType.NATSUKASHINORUDE_POWER_DOWN: {
         return resolveNatsukashinorudePowerDown(gameModel, gameChainLink);
+      }
+      case EffectType.SUPERNEWVOLTS_DESTROY_MONSTER: {
+        return resolveSupernewvoltsDestroyMonster(gameModel, gameChainLink);
       }
       default: {
         const _exhaustiveCheck: never = gameChainLink.effect;

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster.spec.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster.spec.ts
@@ -1,0 +1,116 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { GameChainLinkModel, GameChainLinkStatus } from 'src/models/game-chain-link.model';
+import { EffectType, Zone, StateType } from 'src/graphql/index';
+import { resolveSupernewvoltsDestroyMonster } from './supernewvoltsDestroyMonster';
+
+// Mock the helper functions
+jest.mock('./supernewvoltsDestroyMonster/moveDeckTopCardToMorgue');
+jest.mock('./supernewvoltsDestroyMonster/moveTargetMonsterToMorgue');
+jest.mock('./supernewvoltsDestroyMonster/saveEffectUseCountGameState');
+jest.mock('src/game/mutations/markGameChainLinkAsResolved');
+
+import { moveDeckTopCardToMorgue } from './supernewvoltsDestroyMonster/moveDeckTopCardToMorgue';
+import { moveTargetMonsterToMorgue } from './supernewvoltsDestroyMonster/moveTargetMonsterToMorgue';
+import { saveEffectUseCountGameState } from './supernewvoltsDestroyMonster/saveEffectUseCountGameState';
+import { markGameChainLinkAsResolved } from 'src/game/mutations/markGameChainLinkAsResolved';
+
+const mockMoveDeckTopCardToMorgue = moveDeckTopCardToMorgue as jest.MockedFunction<typeof moveDeckTopCardToMorgue>;
+const mockMoveTargetMonsterToMorgue = moveTargetMonsterToMorgue as jest.MockedFunction<
+  typeof moveTargetMonsterToMorgue
+>;
+const mockSaveEffectUseCountGameState = saveEffectUseCountGameState as jest.MockedFunction<
+  typeof saveEffectUseCountGameState
+>;
+const mockMarkGameChainLinkAsResolved = markGameChainLinkAsResolved as jest.MockedFunction<
+  typeof markGameChainLinkAsResolved
+>;
+
+describe('resolveSupernewvoltsDestroyMonster', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup default mock implementations
+    mockMoveDeckTopCardToMorgue.mockImplementation(gameModel => gameModel);
+    mockMoveTargetMonsterToMorgue.mockImplementation(gameModel => gameModel);
+    mockSaveEffectUseCountGameState.mockImplementation(gameModel => gameModel);
+    mockMarkGameChainLinkAsResolved.mockImplementation(gameModel => gameModel);
+  });
+
+  it('should execute all effect steps and mark chain link as resolved', () => {
+    const gameCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user1',
+      zone: Zone.BATTLE,
+    });
+
+    const targetGameCard = new GameCardModel({
+      id: 2,
+      currentUserId: 'user2',
+      zone: Zone.BATTLE,
+    });
+
+    const gameChainLink = new GameChainLinkModel({
+      id: 1,
+      orderIndex: 0,
+      userId: 'user1',
+      gameCardId: 1,
+      status: GameChainLinkStatus.RESOLVING,
+      effect: {
+        type: EffectType.SUPERNEWVOLTS_DESTROY_MONSTER,
+        payload: {
+          gameCard,
+          targetGameCard,
+        },
+      },
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameUsers: [],
+      gameCards: [gameCard, targetGameCard],
+      gameChains: [],
+    });
+
+    const result = resolveSupernewvoltsDestroyMonster(gameModel, gameChainLink);
+
+    // Verify all effect steps are called in correct order
+    expect(mockMoveDeckTopCardToMorgue).toHaveBeenCalledWith(gameModel, 'user1');
+    expect(mockMoveTargetMonsterToMorgue).toHaveBeenCalledWith(gameModel, targetGameCard);
+    expect(mockSaveEffectUseCountGameState).toHaveBeenCalledWith(gameModel, gameCard);
+    expect(mockMarkGameChainLinkAsResolved).toHaveBeenCalledWith(gameModel, gameChainLink);
+
+    expect(result).toBe(gameModel);
+  });
+
+  it('should return gameModel unchanged if payload is missing', () => {
+    const gameChainLink = new GameChainLinkModel({
+      id: 1,
+      orderIndex: 0,
+      userId: 'user1',
+      gameCardId: 1,
+      status: GameChainLinkStatus.RESOLVING,
+      effect: {
+        type: EffectType.SUPERNEWVOLTS_DESTROY_MONSTER,
+        payload: null,
+      },
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameUsers: [],
+      gameCards: [],
+      gameChains: [],
+    });
+
+    const result = resolveSupernewvoltsDestroyMonster(gameModel, gameChainLink);
+
+    // No functions should be called if payload is missing
+    expect(mockMoveDeckTopCardToMorgue).not.toHaveBeenCalled();
+    expect(mockMoveTargetMonsterToMorgue).not.toHaveBeenCalled();
+    expect(mockSaveEffectUseCountGameState).not.toHaveBeenCalled();
+    expect(mockMarkGameChainLinkAsResolved).not.toHaveBeenCalled();
+
+    expect(result).toBe(gameModel);
+  });
+});

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster.ts
@@ -1,0 +1,26 @@
+import { GameModel } from 'src/models/game.model';
+import { GameChainLinkModel } from 'src/models/game-chain-link.model';
+import { markGameChainLinkAsResolved } from 'src/game/mutations/markGameChainLinkAsResolved';
+import { moveDeckTopCardToMorgue } from './supernewvoltsDestroyMonster/moveDeckTopCardToMorgue';
+import { moveTargetMonsterToMorgue } from './supernewvoltsDestroyMonster/moveTargetMonsterToMorgue';
+import { saveEffectUseCountGameState } from './supernewvoltsDestroyMonster/saveEffectUseCountGameState';
+
+export const resolveSupernewvoltsDestroyMonster = (
+  gameModel: GameModel,
+  gameChainLink: GameChainLinkModel,
+): GameModel => {
+  if (!gameChainLink.effect.payload) {
+    return gameModel;
+  }
+
+  const { gameCard, targetGameCard } = gameChainLink.effect.payload;
+
+  // Perform the effect: deck top to morgue, target monster to morgue, save effect count
+  gameModel = moveDeckTopCardToMorgue(gameModel, gameChainLink.userId);
+  gameModel = moveTargetMonsterToMorgue(gameModel, targetGameCard);
+  gameModel = saveEffectUseCountGameState(gameModel, gameCard);
+
+  gameModel = markGameChainLinkAsResolved(gameModel, gameChainLink);
+
+  return gameModel;
+};

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveDeckTopCardToMorgue.spec.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveDeckTopCardToMorgue.spec.ts
@@ -1,0 +1,105 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { Zone } from 'src/graphql';
+import { moveDeckTopCardToMorgue } from './moveDeckTopCardToMorgue';
+import { calcNewMorgueGameCardPosition } from 'src/game/selectors/calcNewMorgueGameCardPosition';
+import { handleEvent } from 'src/game/events/handlers';
+
+// Mock dependencies
+jest.mock('src/game/selectors/calcNewMorgueGameCardPosition');
+jest.mock('src/game/events/handlers');
+
+const mockCalcNewMorgueGameCardPosition = calcNewMorgueGameCardPosition as jest.MockedFunction<
+  typeof calcNewMorgueGameCardPosition
+>;
+const mockHandleEvent = handleEvent as jest.MockedFunction<typeof handleEvent>;
+
+describe('moveDeckTopCardToMorgue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCalcNewMorgueGameCardPosition.mockReturnValue(0);
+    mockHandleEvent.mockImplementation((event, gameModel) => gameModel);
+  });
+
+  it('should move top deck card to morgue', () => {
+    const topCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user1',
+      zone: Zone.DECK,
+      position: 0,
+    });
+
+    const bottomCard = new GameCardModel({
+      id: 2,
+      currentUserId: 'user1',
+      zone: Zone.DECK,
+      position: 1,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameCards: [bottomCard, topCard], // Order doesn't matter, position determines top
+    });
+
+    mockCalcNewMorgueGameCardPosition.mockReturnValue(5);
+
+    const result = moveDeckTopCardToMorgue(gameModel, 'user1');
+
+    // Check that the top card was moved to morgue
+    const movedCard = result.gameCards.find(gc => gc.id === 1);
+    expect(movedCard?.zone).toBe(Zone.MORGUE);
+    expect(movedCard?.position).toBe(5);
+    expect(movedCard?.battlePosition).toBe(null);
+
+    // Check that the bottom card remained in deck
+    const remainingCard = result.gameCards.find(gc => gc.id === 2);
+    expect(remainingCard?.zone).toBe(Zone.DECK);
+
+    // Verify position calculation was called
+    expect(mockCalcNewMorgueGameCardPosition).toHaveBeenCalledWith(gameModel, 'user1');
+
+    // Verify event was handled
+    expect(mockHandleEvent).toHaveBeenCalledWith(
+      {
+        type: 'ZONE_CHANGED',
+        gameCardId: 1,
+        fromZone: Zone.DECK,
+        toZone: Zone.MORGUE,
+      },
+      expect.any(GameModel),
+    );
+  });
+
+  it('should return gameModel unchanged if deck is empty', () => {
+    const gameModel = new GameModel({
+      id: 1,
+      gameCards: [],
+    });
+
+    const result = moveDeckTopCardToMorgue(gameModel, 'user1');
+
+    expect(result).toBe(gameModel);
+    expect(mockCalcNewMorgueGameCardPosition).not.toHaveBeenCalled();
+    expect(mockHandleEvent).not.toHaveBeenCalled();
+  });
+
+  it('should return gameModel unchanged if user has no deck cards', () => {
+    const otherUserCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user2',
+      zone: Zone.DECK,
+      position: 0,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameCards: [otherUserCard],
+    });
+
+    const result = moveDeckTopCardToMorgue(gameModel, 'user1');
+
+    expect(result).toBe(gameModel);
+    expect(mockCalcNewMorgueGameCardPosition).not.toHaveBeenCalled();
+    expect(mockHandleEvent).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveDeckTopCardToMorgue.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveDeckTopCardToMorgue.ts
@@ -1,0 +1,45 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { Zone } from 'src/graphql';
+import { handleEvent } from 'src/game/events/handlers';
+import { GameEventType } from 'src/game/events';
+
+import { calcNewMorgueGameCardPosition } from 'src/game/selectors/calcNewMorgueGameCardPosition';
+
+export const moveDeckTopCardToMorgue = (gameModel: GameModel, userId: string): GameModel => {
+  const deckCards = gameModel.gameCards
+    .filter(gc => gc.currentUserId === userId && gc.zone === Zone.DECK)
+    .sort((a, b) => a.position - b.position);
+
+  const topCard = deckCards[0];
+
+  if (!topCard) {
+    return gameModel;
+  }
+
+  const newPosition = calcNewMorgueGameCardPosition(gameModel, userId);
+
+  gameModel.gameCards = gameModel.gameCards.map(gc => {
+    if (gc.id === topCard.id) {
+      return new GameCardModel({
+        ...gc,
+        zone: Zone.MORGUE,
+        position: newPosition,
+        battlePosition: null,
+      });
+    }
+    return gc;
+  });
+
+  gameModel = handleEvent(
+    {
+      type: GameEventType.ZONE_CHANGED,
+      gameCardId: topCard.id,
+      fromZone: topCard.zone,
+      toZone: Zone.MORGUE,
+    },
+    gameModel,
+  );
+
+  return gameModel;
+};

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveTargetMonsterToMorgue.spec.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveTargetMonsterToMorgue.spec.ts
@@ -1,0 +1,107 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { Zone } from 'src/graphql';
+import { moveTargetMonsterToMorgue } from './moveTargetMonsterToMorgue';
+import { calcNewMorgueGameCardPosition } from 'src/game/selectors/calcNewMorgueGameCardPosition';
+import { handleEvent } from 'src/game/events/handlers';
+
+// Mock dependencies
+jest.mock('src/game/selectors/calcNewMorgueGameCardPosition');
+jest.mock('src/game/events/handlers');
+
+const mockCalcNewMorgueGameCardPosition = calcNewMorgueGameCardPosition as jest.MockedFunction<
+  typeof calcNewMorgueGameCardPosition
+>;
+const mockHandleEvent = handleEvent as jest.MockedFunction<typeof handleEvent>;
+
+describe('moveTargetMonsterToMorgue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCalcNewMorgueGameCardPosition.mockReturnValue(0);
+    mockHandleEvent.mockImplementation((event, gameModel) => gameModel);
+  });
+
+  it('should move target monster to morgue', () => {
+    const targetCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user2',
+      zone: Zone.BATTLE,
+      position: 1,
+      battlePosition: 'ATTACK',
+    });
+
+    const otherCard = new GameCardModel({
+      id: 2,
+      currentUserId: 'user1',
+      zone: Zone.BATTLE,
+      position: 0,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameCards: [targetCard, otherCard],
+    });
+
+    mockCalcNewMorgueGameCardPosition.mockReturnValue(3);
+
+    const result = moveTargetMonsterToMorgue(gameModel, targetCard);
+
+    // Check that the target card was moved to morgue
+    const movedCard = result.gameCards.find(gc => gc.id === 1);
+    expect(movedCard?.zone).toBe(Zone.MORGUE);
+    expect(movedCard?.position).toBe(3);
+    expect(movedCard?.battlePosition).toBe(null);
+
+    // Check that the other card remained unchanged
+    const unchangedCard = result.gameCards.find(gc => gc.id === 2);
+    expect(unchangedCard?.zone).toBe(Zone.BATTLE);
+    expect(unchangedCard?.position).toBe(0);
+
+    // Verify position calculation was called with target card's owner
+    expect(mockCalcNewMorgueGameCardPosition).toHaveBeenCalledWith(gameModel, 'user2');
+
+    // Verify event was handled
+    expect(mockHandleEvent).toHaveBeenCalledWith(
+      {
+        type: 'ZONE_CHANGED',
+        gameCardId: 1,
+        fromZone: Zone.BATTLE,
+        toZone: Zone.MORGUE,
+      },
+      expect.any(GameModel),
+    );
+  });
+
+  it('should handle cards from different zones', () => {
+    const targetCard = new GameCardModel({
+      id: 1,
+      currentUserId: 'user1',
+      zone: Zone.HAND,
+      position: 2,
+    });
+
+    const gameModel = new GameModel({
+      id: 1,
+      gameCards: [targetCard],
+    });
+
+    mockCalcNewMorgueGameCardPosition.mockReturnValue(1);
+
+    const result = moveTargetMonsterToMorgue(gameModel, targetCard);
+
+    const movedCard = result.gameCards.find(gc => gc.id === 1);
+    expect(movedCard?.zone).toBe(Zone.MORGUE);
+    expect(movedCard?.position).toBe(1);
+
+    // Verify event shows correct fromZone
+    expect(mockHandleEvent).toHaveBeenCalledWith(
+      {
+        type: 'ZONE_CHANGED',
+        gameCardId: 1,
+        fromZone: Zone.HAND,
+        toZone: Zone.MORGUE,
+      },
+      expect.any(GameModel),
+    );
+  });
+});

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveTargetMonsterToMorgue.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/moveTargetMonsterToMorgue.ts
@@ -1,0 +1,34 @@
+import { GameModel } from 'src/models/game.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { Zone } from 'src/graphql';
+import { handleEvent } from 'src/game/events/handlers';
+import { GameEventType } from 'src/game/events';
+import { calcNewMorgueGameCardPosition } from 'src/game/selectors/calcNewMorgueGameCardPosition';
+
+export const moveTargetMonsterToMorgue = (gameModel: GameModel, targetGameCard: GameCardModel): GameModel => {
+  const newPosition = calcNewMorgueGameCardPosition(gameModel, targetGameCard.currentUserId);
+
+  gameModel.gameCards = gameModel.gameCards.map(gc => {
+    if (gc.id === targetGameCard.id) {
+      return new GameCardModel({
+        ...gc,
+        zone: Zone.MORGUE,
+        position: newPosition,
+        battlePosition: null,
+      });
+    }
+    return gc;
+  });
+
+  gameModel = handleEvent(
+    {
+      type: GameEventType.ZONE_CHANGED,
+      gameCardId: targetGameCard.id,
+      fromZone: targetGameCard.zone,
+      toZone: Zone.MORGUE,
+    },
+    gameModel,
+  );
+
+  return gameModel;
+};

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/saveEffectUseCountGameState.spec.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/saveEffectUseCountGameState.spec.ts
@@ -1,0 +1,75 @@
+import { GameModel } from 'src/models/game.model';
+import { GameStateModel } from 'src/models/game-state.model';
+import { GameUserModel } from 'src/models/game-user.model';
+import { StateType, Zone } from 'src/graphql';
+import { saveEffectUseCountGameState } from './saveEffectUseCountGameState';
+import { GameCardModel } from 'src/models/game-card.model';
+import { CardModel } from 'src/models/card.model';
+
+describe('saveEffectUseCountGameState', () => {
+  it('should create new effect use count state when none exists', () => {
+    const gameUser = new GameUserModel();
+    gameUser.id = 1;
+    gameUser.userId = 'user1';
+
+    const card = new CardModel();
+    card.id = 1;
+
+    const supernewvoltsCard = new GameCardModel();
+    supernewvoltsCard.id = 1;
+    supernewvoltsCard.currentUserId = 'user1';
+    supernewvoltsCard.zone = Zone.BATTLE;
+    supernewvoltsCard.card = card;
+
+    const gameEntity = new GameModel();
+    gameEntity.gameUsers = [gameUser];
+    gameEntity.gameCards = [supernewvoltsCard];
+    gameEntity.gameStates = [];
+
+    const result = saveEffectUseCountGameState(gameEntity, supernewvoltsCard);
+
+    expect(result.gameStates).toHaveLength(1);
+    expect(result.gameStates[0]?.state.type).toBe(StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT);
+    expect(result.gameStates[0]?.gameCardId).toBe(1);
+
+    const state = result.gameStates[0]?.state;
+    if (state?.type === StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT) {
+      expect(state.data.value).toBe(1);
+    }
+  });
+
+  it('should increment existing effect use count state', () => {
+    const gameUser = new GameUserModel();
+    gameUser.id = 1;
+    gameUser.userId = 'user1';
+
+    const card = new CardModel();
+    card.id = 1;
+
+    const supernewvoltsCard = new GameCardModel();
+    supernewvoltsCard.id = 1;
+    supernewvoltsCard.currentUserId = 'user1';
+    supernewvoltsCard.zone = Zone.BATTLE;
+    supernewvoltsCard.card = card;
+
+    const existingState = new GameStateModel();
+    existingState.gameCardId = supernewvoltsCard.id;
+    existingState.state = { type: StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT, data: { value: 1 } };
+
+    const gameEntity = new GameModel();
+    gameEntity.gameUsers = [gameUser];
+    gameEntity.gameCards = [supernewvoltsCard];
+    gameEntity.gameStates = [existingState];
+
+    const result = saveEffectUseCountGameState(gameEntity, supernewvoltsCard);
+
+    expect(result.gameStates).toHaveLength(1);
+    expect(result.gameStates[0]?.state.type).toBe(StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT);
+    expect(result.gameStates[0]?.gameCardId).toBe(1);
+
+    const state = result.gameStates[0]?.state;
+    if (state?.type === StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT) {
+      expect(state.data.value).toBe(2);
+    }
+  });
+});

--- a/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/saveEffectUseCountGameState.ts
+++ b/server/src/game/chains/resolvers/supernewvoltsDestroyMonster/saveEffectUseCountGameState.ts
@@ -1,0 +1,40 @@
+import { GameModel } from 'src/models/game.model';
+import { GameStateModel } from 'src/models/game-state.model';
+import { GameCardModel } from 'src/models/game-card.model';
+import { StateType } from 'src/graphql';
+
+const initEffectUseCountGameState = (gameModel: GameModel, gameCard: GameCardModel): GameStateModel => {
+  return new GameStateModel({
+    gameCardId: gameCard.id,
+    state: { type: StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT, data: { value: 1 } },
+  });
+};
+
+export const saveEffectUseCountGameState = (gameModel: GameModel, gameCard: GameCardModel): GameModel => {
+  const existsState =
+    gameModel.gameStates.findIndex(
+      gameState =>
+        gameState.state.type === StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT &&
+        gameState.gameCardId === gameCard.id,
+    ) >= 0;
+
+  if (existsState) {
+    gameModel.gameStates = gameModel.gameStates.map(gameState =>
+      gameState.state.type === StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT &&
+      gameState.gameCardId === gameCard.id
+        ? new GameStateModel({
+            ...gameState,
+            state: {
+              type: StateType.EFFECT_SUPERNEWVOLTS_DESTROY_MONSTER_COUNT,
+              data: { value: gameState.state.data.value + 1 },
+            },
+          })
+        : gameState,
+    );
+
+    return gameModel;
+  }
+
+  gameModel.gameStates.push(initEffectUseCountGameState(gameModel, gameCard));
+  return gameModel;
+};


### PR DESCRIPTION
Implements chain system refactoring for `effectSupernewvoltsDestroyMonster` following the pattern established by `effectRuteruteDraw`.

## Changes
- Update action handler to create GameChain/GameChainLink instead of direct effect processing
- Add chain resolver for SUPERNEWVOLTS_DESTROY_MONSTER effect type
- Move effect logic (deck top to morgue, target monster to morgue, effect count) to chain resolver
- Add comprehensive specs for action handler, chain resolver, and helper functions

Resolves #49

🤖 Generated with [Claude Code](https://claude.ai/code)