### PR TITLE
fix: prevent chain processing when game ends in dispatchAction

### DIFF
--- a/server/src/services/game.service.ts
+++ b/server/src/services/game.service.ts
@@ -48,6 +48,11 @@ export class GameService {
         this.gameActionHandler.handleAction(data, userId, grantedGameModel),
       );
 
+      // チェーン処理前のゲーム終了チェック
+      if (handledGameModel.endedAt !== null) {
+        return await manager.save(handledGameModel.toEntity());
+      }
+
       // GameChainを解決
       const resolvedGameModel = this.chainResolver.resolveChain(handledGameModel);
 


### PR DESCRIPTION
Add game end check before chain building to fix bug where Takibī's 1000 damage effect continues processing after direct attack damage already ends the game.

Fixes #66

Generated with [Claude Code](https://claude.ai/code)