### PR TITLE
Fix opponent Morgue zone card orientation

### DIFF
--- a/client/src/components/game/three/ThreeGameCardStack.tsx
+++ b/client/src/components/game/three/ThreeGameCardStack.tsx
@@ -15,6 +15,7 @@ const STACK_COUNT = 3;
 export type ThreeGameCardStackProps = {
   gameCards: GameCardFragment[];
   position: [number, number, number];
+  isYours: boolean;
 };
 
 function StackMeshes({
@@ -22,11 +23,13 @@ function StackMeshes({
   position,
   topTexture,
   backTexture,
+  isYours,
 }: {
   targetGameCards: GameCardFragment[];
   position: [number, number, number];
   topTexture: THREE.Texture;
   backTexture: THREE.Texture;
+  isYours: boolean;
 }) {
   const {
     state: { gameCardListModal },
@@ -64,11 +67,14 @@ function StackMeshes({
           new THREE.MeshStandardMaterial({ color: '#1a1a1a' }),
         ];
 
+        // Apply same rotation logic as ThreeGameCard: opponent cards are rotated 180° around Y
+        const baseYRot = isYours ? 0 : Math.PI;
+
         return (
           <mesh
             key={i}
             position={[position[0], yPos, position[2]]}
-            rotation={[0, 0, 0]}
+            rotation={[0, baseYRot, 0]}
             material={materials}
             onPointerDown={isTop ? handleClick : undefined}
             onPointerEnter={
@@ -97,6 +103,7 @@ function StackMeshes({
 function ThreeGameCardStackInner({
   gameCards,
   position,
+  isYours,
 }: ThreeGameCardStackProps) {
   const topGameCard = findTopGameCard(gameCards);
   const topUrl = topGameCard?.card?.picture ?? BACK_SIDE_CARD;
@@ -109,6 +116,7 @@ function ThreeGameCardStackInner({
       position={position}
       topTexture={topTexture}
       backTexture={backTexture}
+      isYours={isYours}
     />
   );
 }

--- a/client/src/components/game/three/ZoneCards3D.tsx
+++ b/client/src/components/game/three/ZoneCards3D.tsx
@@ -42,7 +42,13 @@ export default function ZoneCards3D({
   const center = ZONE_POSITIONS[key];
 
   if (STACK_ZONES.has(zone)) {
-    return <ThreeGameCardStack gameCards={gameCards} position={center} />;
+    return (
+      <ThreeGameCardStack
+        gameCards={gameCards}
+        position={center}
+        isYours={isYours}
+      />
+    );
   }
 
   const count = gameCards.length;


### PR DESCRIPTION
Fixes #76

The opponent's cards in the Morgue zone had incorrect orientation. This PR fixes the issue by:

- Adding `isYours` prop to `ThreeGameCardStack` component
- Applying the same 180° Y-axis rotation logic for opponent stacks as individual cards
- Ensuring consistent card orientation across all zones

Generated with [Claude Code](https://claude.ai/code)