### PR TITLE
feat: add Terms of Service link to navbar

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -100,6 +100,9 @@ export default function Navbar() {
             <StyledNavLink tag={RRDNavLink} exact to="/rule">
               ルール
             </StyledNavLink>
+            <StyledNavLink tag={RRDNavLink} exact to="/terms">
+              利用規約
+            </StyledNavLink>
           </Nav>
           <Nav>
             {(() => {


### PR DESCRIPTION
Implements #79

Adds Terms of Service (利用規約) link to the navigation bar for easy access to the terms page.

## Changes
- Add Terms of Service link to navbar component
- Link positioned after Rules link in navigation menu
- Follows existing navbar patterns and styling
- Accessible to all users (logged in and out)

## Testing
- ✅ Build passes for both client and server
- ✅ Code formatting applied

Generated with [Claude Code](https://claude.ai/code)